### PR TITLE
Partial impl of profile show option (#17).

### DIFF
--- a/pyltc/main.py
+++ b/pyltc/main.py
@@ -37,4 +37,6 @@ def pyltc_entry_point(argv=None, target_factory=None):
 
 
 if __name__ == '__main__':
+    # for local testing and experimenting
+    # pyltc_entry_point(['profile', '4g', '-c', '../test.profile', '-s'])
     pyltc_entry_point(['simnet', '-c', '--interface', 'lo', '-v', '--upload'])


### PR DESCRIPTION
- `SimnetPugin.load_profile()` now does the profile parsing AND execution, to be able to skip actual execution in case of `profile show` option (as per #17).
- Profile invocation w/o profile name is NOT supported yet, as it requires redesign of the command line arguments system (going to happen when working on #22.)

@thehunmonkgroup: please test well enough before approving this PR, thanks.